### PR TITLE
detect timeout as positional argument in urlopen

### DIFF
--- a/flake8_timeout.py
+++ b/flake8_timeout.py
@@ -52,7 +52,11 @@ class Visitor(ast.NodeVisitor):
                 ):
                     break
             else:
-                self.assignments.append((node.lineno, node.col_offset))
+                # check if it was passed as a positional argument instead
+                # args are: (url, data=None, [timeout, ]*, cafile=None ...
+                if len(node.args) < 3:
+                    self.assignments.append((node.lineno, node.col_offset))
+
         self.generic_visit(node)
 
 

--- a/tests/flake8_timeout_test.py
+++ b/tests/flake8_timeout_test.py
@@ -50,6 +50,11 @@ def test_timout_is_kwarg(s):
     assert not results(s)
 
 
+def test_timout_is_arg():
+    s = 'a = urllib.request.urlopen("https://example.com", None, 5, arg="t")'
+    assert not results(s)
+
+
 @pytest.mark.parametrize(
     's',
     (
@@ -81,13 +86,13 @@ def test_call_as_kwarg(s):
 @pytest.mark.parametrize(
     's',
     (
-        'a = foo(bar=requests.get("https://example.com"))',
-        'a = foo(bar=urllib.request.urlopen("https://example.com"))',
+        'a = foo(requests.get("https://example.com"))',
+        'a = foo(urllib.request.urlopen("https://example.com"))',
     ),
 )
 def test_call_as_arg(s):
     msg, = results(s)
-    assert msg == '1:12: TIM100 request call has no timeout'
+    assert msg == '1:8: TIM100 request call has no timeout'
 
 
 @pytest.mark.parametrize(
@@ -97,7 +102,7 @@ def test_call_as_arg(s):
         'foo(bar=urllib.request.urlopen("https://example.com"))',
     ),
 )
-def test_call_as_arg_no_assing(s):
+def test_call_as_kwarg_no_assing(s):
     msg, = results(s)
     assert msg == '1:8: TIM100 request call has no timeout'
 


### PR DESCRIPTION
now `urllib.request.urlopen("https://example.com", None, 5)`(positional argument) is also allowed instead of only as a keyword argument: `urllib.request.urlopen("https://example.com", None, timeout=5)`

also fixing one copy pasta and typos in the tests.